### PR TITLE
Fix options statuses not merged

### DIFF
--- a/lib/Octogun/Client/Statuses.php
+++ b/lib/Octogun/Client/Statuses.php
@@ -40,7 +40,7 @@ class Statuses extends Api
      */
     public function createStatus($repo, $sha, $state, array $options = array())
     {
-        $options = array_merge(array(
+        $options = array_merge($options, array(
             'state' => $state,
         ));
         


### PR DESCRIPTION
I was making this request but the options were not sent to the server :

```php
$status = $statuses->createStatus(
    '<user/repo>',
    '<sha>',
    '<state>', 
    array(
        'description' => '<description>',
        'target_url' => '<url>',
        'context' => '<context/service>',
    )
);
```

Great repo by the way. :)